### PR TITLE
Added DEI.md file for CHAOSS project badging, to highlight Django's dedication to diversity, equity and inclusion.

### DIFF
--- a/DEI.md
+++ b/DEI.md
@@ -1,0 +1,90 @@
+# Diversity, Equity, and Inclusion Project Statement
+
+<!---
+The DEI.md file was originally created in the CHAOSS project. This comment provides attribution of that work as defined 
+under the MIT license. 
+-->
+
+<!---
+Please use the DEI.md Guide at https://github.com/AllInOpenSource/ProjectBadging/blob/main/Guide.DEI.md when creating 
+your DEI.md file
+-->
+
+<img src="https://static.djangoproject.com/img/logos/django-logo-negative.svg" alt="Django" style="width:200px;"/>
+
+Scope of the DEI.md File
+
+Our project prioritizes and reflects on DEI through a regular review of project policies and performance. This 
+reflection is documented in the following DEI.md file based on specific [CHAOSS project](https://chaoss.community) 
+DEI metrics. 
+
+### [Project Access](https://chaoss.community/?p=4953)
+Project access is addressed in our project through various efforts. Through these efforts, we aim to support access for 
+all. Specific efforts in our project include:
+* Our Django Fellows span global time zones and work asynchronously with contributors across the world.
+* The Django documentation and the Django framework itself has multiple translations.
+* All areas of Django are considered open to community contributions, including joining a translation team, conference 
+organising or volunteering, running for the Django Software Foundation (DSF) board, Django ticket triage etc.
+* DSF membership, which recognizes contributors to Django, is open to non-code contributors, including contributions 
+through events, blog posts, and comments in issues and merge requests.
+* We have an Accessibility Team dedicated to improving the accessibility of Django.
+* DjangoCons offer opportunity grants to make the conferences accessible to those who are new and/or financially 
+constrained.
+* DjangoCons make it a priority to offer childcare reimbursements and private facilities for breastfeeding.
+* DjangoCon talks have in place human captioners which make talks more accessible - especially to those hard of hearing 
+and language learners.
+
+_Note: the extra provisions and opportunity grants are only possible at DjangoCons due to our generous sponsors. 
+DjangoCons have diversity and accessibility packages which allow sponsors to specifically fund these efforts._
+  
+### [Communication Transparency](https://chaoss.community/?p=4957)
+Communication Transparency is addressed in our project through a variety of different efforts. Through these efforts, we 
+aim to support transparency for all. Specific efforts in our project include: 
+* All project documentation is publicly available at [djangoproject.com](https://djangoproject.com).
+* Decisions that impact Django are shared via the DSF Board 
+[meeting minutes](https://www.djangoproject.com/foundation/minutes/).
+* [Statistics of Code of Conduct reports](https://github.com/django/code-of-conduct/blob/main/statistics.md) are 
+publicly available.
+* DjangoCon talks are publicly available - [DjangoCon Europe](https://www.youtube.com/@djangoconeurope), 
+[DjangoCon US](https://www.youtube.com/@DjangoConUS)
+* [Trac (Django's ticketing system)](https://code.djangoproject.com/query) is publicly available. All actions are open 
+including creating new tickets, commenting on and updating existing tickets (with a GitHub account).
+* The [Django forum](https://forum.djangoproject.com/) hosts discussions where anyone can post, comment and like (with a 
+GitHub account).
+* The [Django Discord](https://discord.gg/xcRH6mN4fa) is publicly available (with a Discord account).
+           
+### [Newcomer Experiences](https://chaoss.community/?p=4891)
+The newcomer experience is addressed in our project through a variety of different efforts. Through these efforts, we 
+aim to support the newcomer experience for all new members. Specific efforts in our project include:
+* A quick start guide for newcomers is available on our website and made available through the main website navigation.
+* Django has an automatic welcome message for first time contributors to Django who are awaiting a response to a merge 
+request.
+* Django's contributor documentation includes a full walkthrough tutorial for newcomers to make their first 
+contribution. This includes setting up the development environment, making code changes, documentation updates and ways 
+to find support.
+* Django conferences welcome and prioritise new speakers.
+* The [Django forum](https://forum.djangoproject.com/) and [Django Discord](https://discord.gg/xcRH6mN4fa) have 
+dedicated support channels and active moderators.
+* [Djangonaut Space](https://djangonaut.space/) is a mentorship program aiming develop future leaders of Django.
+  
+### [Inclusive Leadership](https://chaoss.community/?p=3522)
+Inclusive leadership is addressed in our project through a variety of different efforts. Through these efforts, we aim 
+to support leadership opportunities for project members with an interest. Specific efforts in our project include: 
+* DSF Board members have limited terms which require a renewal via a community vote. Everyone in the community can run 
+to be a member of the Board.
+* Django is community run. All decision-making/leadership responsibilities are help by groups rather than individuals.
+* The DSF membership has historically and continues to elect members for the 
+[DSF Board](https://www.djangoproject.com/foundation/#board) that are diverse in terms of gender, age, race, geography, 
+and more.
+* The Code of Conduct committee enforces the code of conduct consistently.
+
+Our project recognizes that the inclusion of the DEI.md file and the provided reflection on the specific DEI metrics 
+does not ensure community safety nor community inclusiveness. The inclusion of the DEI.md file signals that we, as a 
+project, are committed to centering DEI in our project and regularly reviewing and reflecting on our project DEI 
+practices.
+
+If you do not feel that the DEI.md file appropriately addresses concerns you have about community safety and 
+inclusiveness, please let us know. You can do this by reporting your concerns to our 
+[Code of Conduct team](https://www.djangoproject.com/foundation/committees/#conduct) to raise concerns you have.
+
+Last Reviewed: 2023-11-14


### PR DESCRIPTION
References:
- https://github.com/badging/ProjectBadging
- https://github.blog/2023-06-07-announcing-the-all-in-chaoss-dei-badging-pilot-initiative/
- https://allinopensource.org/maintainers/DEI-badging/

You can review the file here: https://github.com/sarahboyce/django.github/blob/dei/DEI.md

Once we have a DEI.md file, we can submit the repository to be scanned and we would be issued a DEI badge which we can share on our org and project README.md