### PR TITLE
Fix tagline (again)

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,6 +1,6 @@
 # Django
 
-> The Web framework for perfectionists with deadlines. 
+> The web framework for perfectionists with deadlines. 
 
 Let's go! Here are some useful links to get you started: 
 


### PR DESCRIPTION
Follow-up from #3. It’s important we’re consistent with the exact spelling to match other Django-branded content. The tagline has _web_ lowercase on the Django website, and other branded assets I’m aware of.